### PR TITLE
Add SenderDispatcher

### DIFF
--- a/src/graia/ariadne/dispatcher.py
+++ b/src/graia/ariadne/dispatcher.py
@@ -105,5 +105,8 @@ class SenderDispatcher(BaseDispatcher):
 
     @staticmethod
     async def catch(interface: DispatcherInterface):
-        if isinstance(interface.event.sender, interface.annotation):
-            return interface.event.sender
+        from .event.message import MessageEvent
+
+        if isinstance(interface.event, MessageEvent):
+            if isinstance(interface.event.sender, interface.annotation):
+                return interface.event.sender

--- a/src/graia/ariadne/dispatcher.py
+++ b/src/graia/ariadne/dispatcher.py
@@ -94,3 +94,16 @@ class SourceDispatcher(BaseDispatcher):
         if isinstance(interface.event, MessageEvent):
             if interface.annotation is Source:
                 return interface.event.messageChain.getFirst(Source)
+
+
+class SenderDispatcher(BaseDispatcher):
+    """
+    从 MessageEvent 提取 sender 的 Dispatcher.
+    支持实现了 __instancecheck__ 的注释, 如 Union, Optional (since Python3.10)
+    和被 typing.runtime_checkable 标记为运行时协议的 Protocol.
+    """
+
+    @staticmethod
+    async def catch(interface: DispatcherInterface):
+        if isinstance(interface.event.sender, interface.annotation):
+            return interface.event.sender

--- a/src/graia/ariadne/event/message.py
+++ b/src/graia/ariadne/event/message.py
@@ -4,7 +4,7 @@ from typing import Union
 from graia.broadcast.entities.dispatcher import BaseDispatcher
 from graia.broadcast.interfaces.dispatcher import DispatcherInterface
 
-from ..dispatcher import ContextDispatcher, MessageChainDispatcher, SourceDispatcher
+from ..dispatcher import ContextDispatcher, MessageChainDispatcher, SourceDispatcher, SenderDispatcher
 from ..message.chain import MessageChain
 from ..model import Client, Friend, Group, Member, Stranger
 from . import MiraiEvent
@@ -19,7 +19,7 @@ class MessageEvent(MiraiEvent):
     sender: Union[Friend, Member, Client, Stranger]
 
     class Dispatcher(BaseDispatcher):  # pylint: disable=missing-class-docstring
-        mixin = [MessageChainDispatcher, ContextDispatcher, SourceDispatcher]
+        mixin = [MessageChainDispatcher, ContextDispatcher, SourceDispatcher, SenderDispatcher]
 
         @staticmethod
         async def catch(*_):
@@ -34,7 +34,7 @@ class FriendMessage(MessageEvent, FriendEvent):
     sender: Friend
 
     class Dispatcher(BaseDispatcher):  # pylint: disable=missing-class-docstring
-        mixin = [MessageChainDispatcher, ContextDispatcher, SourceDispatcher]
+        mixin = [MessageChainDispatcher, ContextDispatcher, SourceDispatcher, SenderDispatcher]
 
         @staticmethod
         async def catch(interface: DispatcherInterface):
@@ -51,7 +51,7 @@ class GroupMessage(MessageEvent, GroupEvent):
     sender: Member
 
     class Dispatcher(BaseDispatcher):  # pylint: disable=missing-class-docstring
-        mixin = [MessageChainDispatcher, ContextDispatcher, SourceDispatcher]
+        mixin = [MessageChainDispatcher, ContextDispatcher, SourceDispatcher, SenderDispatcher]
 
         @staticmethod
         async def catch(interface: DispatcherInterface):
@@ -70,8 +70,7 @@ class TempMessage(MessageEvent):
     sender: Member
 
     class Dispatcher(BaseDispatcher):  # pylint: disable=missing-class-docstring
-
-        mixin = [MessageChainDispatcher, ContextDispatcher, SourceDispatcher]
+        mixin = [MessageChainDispatcher, ContextDispatcher, SourceDispatcher, SenderDispatcher]
 
         @staticmethod
         async def catch(interface: DispatcherInterface):
@@ -90,8 +89,7 @@ class OtherClientMessage(MessageEvent):
     sender: Client
 
     class Dispatcher(BaseDispatcher):  # pylint: disable=missing-class-docstring
-
-        mixin = [MessageChainDispatcher, ContextDispatcher, SourceDispatcher]
+        mixin = [MessageChainDispatcher, ContextDispatcher, SourceDispatcher, SenderDispatcher]
 
         @staticmethod
         async def catch(interface: DispatcherInterface):
@@ -108,8 +106,7 @@ class StrangerMessage(MessageEvent):
     sender: Stranger
 
     class Dispatcher(BaseDispatcher):  # pylint: disable=missing-class-docstring
-
-        mixin = [MessageChainDispatcher, ContextDispatcher, SourceDispatcher]
+        mixin = [MessageChainDispatcher, ContextDispatcher, SourceDispatcher, SenderDispatcher]
 
         @staticmethod
         async def catch(interface: DispatcherInterface):


### PR DESCRIPTION
添加 SenderDispatcher 以允许实现了 \_\_instancecheck\_\_ 方法的类作注释, 如 Union, Optional (since Python3.10) 和被 typing.runtime_checkable 标记为运行时协议的 Protocol.
这使得同时监听多种 MessageEvent 时, 获取 `sender` 变得更加简单:
```python
@channel.use(ListenerSchema([FriendMessage, GroupMessage]))
async def listener(app: Ariadne, target: Union[Friend, Group]):
    ...
    await app.sendMessage(target, MessageChain(...))
```