### PR TITLE
💡add skip_for_unmatch arg

### DIFF
--- a/docs/advance/alconna/quickstart.md
+++ b/docs/advance/alconna/quickstart.md
@@ -31,7 +31,7 @@ async def friend_message_listener(app: Ariadne, friend: Friend, song_name: str, 
  <li class="chat left">歌名是 大地</li>
  <li class="chat left">歌手是 Beyond</li>
  <li class="chat right">!点歌 --help</li>
- <li class="chat left">!点歌 &lt;song_name&gt;&#13;在XXX中搜索歌名&#13;可用的选项有:&#13;# 指定歌手\n  -s, --歌手 &lt;singer_name&gt;</li>
+ <li class="chat left">!点歌 &lt;song_name&gt;<br>在XXX中搜索歌名<br>可用的选项有:<br>&#35; 指定歌手<br>  -s, --歌手 &lt;singer_name&gt;</li>
 </ul>
 </div>
 

--- a/docs/advance/alconna/quickstart.md
+++ b/docs/advance/alconna/quickstart.md
@@ -6,12 +6,11 @@
     `BlueGlassBlock` 仅进行了针对 `Ariadne` 的封装, 本模块余下部分从 `Alconna wiki` 复制并修改而来.
 
 ```python
-from graia.ariadne.message.parser.alconna import (
-    AlconnaDispatcher,
-    Alconna
-)
+from arclet.alconna import AlconnaString
+from graia.ariadne.message.parser.alconna import AlconnaDispatcher
+
 # example: !点歌 <歌名> --歌手 <歌手名>                       
-music = Alconna.from_string(
+music = AlconnaString(
     "!点歌 <song_name:str>  #在XXX中搜索歌名", # 主参数: <歌名>
     "--歌手|-s <singer_name:str> #指定歌手"  # 选项名: --歌手  选项别名: -s  选项参数: <歌手名>   
 )
@@ -84,6 +83,15 @@ Alconna(
 -   `AlconnaProperty`: 在 `name` 上进行此标注等价于进行 `arpamar.get(name)`.
 -   `dict`: 当`name`代表`Alconna`内的选项, 并且确实解析到数据时返回对应的字典对象; 未解析时为None
 -   其他类型: 在 `name` 上进行此标注等价于`arpamar.all_matched_args.get(name)`; 未解析时为None
+
+## 特殊事件
+
+当`AlconnaDispatcher`的`reply_help`为`False`时, 其会向bcc广播一个`AlconnaHelpMessage`事件
+
+该事件可获取的参数如下:
+- `help_string`(str): 可能的帮助信息
+- `alconna` (Alconna): 该帮助信息对应的命令
+- `sender`, `messageChain`, `app`, ...: 从源消息事件中可获取的所有参数
 
 ## 与 Twilight 对比
 

--- a/src/graia/ariadne/message/parser/alconna.py
+++ b/src/graia/ariadne/message/parser/alconna.py
@@ -7,23 +7,23 @@ from typing import TYPE_CHECKING
 from arclet.alconna import (
     Alconna,
     Arpamar,
-    change_help_send_action,
     MessageChain,
     NonTextElement,
     ParamsUnmatched,
-    compile
+    change_help_send_action,
+    compile,
 )
+from graia.broadcast.entities.dispatcher import BaseDispatcher
+from graia.broadcast.entities.event import Dispatchable
 from graia.broadcast.entities.signatures import Force
 from graia.broadcast.exceptions import ExecutionStop
-from graia.broadcast.entities.event import Dispatchable
-from graia.broadcast.entities.dispatcher import BaseDispatcher
 from graia.broadcast.interfaces.dispatcher import DispatcherInterface
 
 from ... import get_running
 from ...app import Ariadne
+from ...dispatcher import ContextDispatcher
 from ...event.message import MessageEvent
 from ..chain import MessageChain as GraiaMessageChain
-from ...dispatcher import ContextDispatcher
 
 if TYPE_CHECKING:
     ArpamarProperty = type("ArpamarProperty", (str, MessageChain, NonTextElement), {})
@@ -37,6 +37,7 @@ class AlconnaHelpMessage(Dispatchable):
 
     如果触发的某个命令的帮助选项, 当AlconnaDisptcher的reply_help为False时, 会发送该事件
     """
+
     command: Alconna
     """命令"""
 
@@ -85,17 +86,16 @@ class AlconnaDispatcher(BaseDispatcher):
             app: Ariadne = get_running()
 
             def _send_help_string(help_string: str):
-                app.loop.create_task(
-                    app.sendMessage(event.sender, GraiaMessageChain.create(help_string))
-                )
+                app.loop.create_task(app.sendMessage(event.sender, GraiaMessageChain.create(help_string)))
 
             change_help_send_action(_send_help_string)
         else:
+
             def _post_help(help_string: str):
                 interface.broadcast.postEvent(
-                    AlconnaHelpMessage(self.analyser.alconna, help_string),
-                    upper_event=event
+                    AlconnaHelpMessage(self.analyser.alconna, help_string), upper_event=event
                 )
+
             change_help_send_action(_post_help)
 
         local_storage = interface.local_storage
@@ -124,4 +124,3 @@ class AlconnaDispatcher(BaseDispatcher):
         if issubclass(interface.annotation, ArpamarProperty):
             return arpamar.get(interface.name)
         return Force()
-

--- a/src/graia/ariadne/message/parser/alconna.py
+++ b/src/graia/ariadne/message/parser/alconna.py
@@ -7,25 +7,55 @@ from typing import TYPE_CHECKING
 from arclet.alconna import (
     Alconna,
     Arpamar,
+    change_help_send_action,
     MessageChain,
     NonTextElement,
     ParamsUnmatched,
-    change_help_send_action,
+    compile
 )
-from graia.broadcast.entities.dispatcher import BaseDispatcher
 from graia.broadcast.entities.signatures import Force
 from graia.broadcast.exceptions import ExecutionStop
+from graia.broadcast.entities.event import Dispatchable
+from graia.broadcast.entities.dispatcher import BaseDispatcher
 from graia.broadcast.interfaces.dispatcher import DispatcherInterface
 
 from ... import get_running
 from ...app import Ariadne
 from ...event.message import MessageEvent
 from ..chain import MessageChain as GraiaMessageChain
+from ...dispatcher import ContextDispatcher
 
 if TYPE_CHECKING:
     ArpamarProperty = type("ArpamarProperty", (str, MessageChain, NonTextElement), {})
 else:
     ArpamarProperty = type("ArpamarProperty", (), {})
+
+
+class AlconnaHelpMessage(Dispatchable):
+    """
+    Alconna帮助信息发送事件
+
+    如果触发的某个命令的帮助选项, 当AlconnaDisptcher的reply_help为False时, 会发送该事件
+    """
+    command: Alconna
+    """命令"""
+
+    help_string: str
+    """帮助信息"""
+
+    def __init__(self, alconna: Alconna, help_string: str):
+        self.command = alconna
+        self.help_string = help_string
+
+    class Dispatcher(BaseDispatcher):
+        mixin = [ContextDispatcher]
+
+        @staticmethod
+        async def catch(interface: "DispatcherInterface[AlconnaHelpMessage]"):
+            if interface.name == "help_string" and interface.annotation == str:
+                return interface.event.help_string
+            if interface.annotation == Alconna:
+                return interface.event.command
 
 
 class AlconnaDispatcher(BaseDispatcher):
@@ -39,32 +69,39 @@ class AlconnaDispatcher(BaseDispatcher):
 
         Args:
             alconna (Alconna): Alconna实例
-            reply_help (bool): 是否自助回复帮助信息给指令的发起者, 默认为 False
+            reply_help (bool): 是否自助回复帮助信息给指令的发起者. 当为 False 时, 会广播一个'AlconnaHelpMessage'事件以交给用户处理帮助信息.
             skip_for_unmatch (bool): 当指令匹配失败时是否跳过对应的事件监听器, 默认为 True
         """
         super().__init__()
-        self.alconna = alconna
+        self.analyser = compile(alconna)
         self.reply_help = reply_help
         self.skip_for_unmatch = skip_for_unmatch
-        if not reply_help:
-            change_help_send_action(lambda x: x)
 
     async def beforeExecution(self, interface: "DispatcherInterface[MessageEvent]"):
         """预处理消息链并存入 local_storage"""
+        event: MessageEvent = await interface.lookup_param("event", MessageEvent, None)
+
         if self.reply_help:
-            event: MessageEvent = await interface.lookup_param("event", MessageEvent, None)
             app: Ariadne = get_running()
 
             def _send_help_string(help_string: str):
-                app.loop.create_task(app.sendMessage(event.sender, GraiaMessageChain.create(help_string)))
+                app.loop.create_task(
+                    app.sendMessage(event.sender, GraiaMessageChain.create(help_string))
+                )
 
             change_help_send_action(_send_help_string)
+        else:
+            def _post_help(help_string: str):
+                interface.broadcast.postEvent(
+                    AlconnaHelpMessage(self.analyser.alconna, help_string),
+                    upper_event=event
+                )
+            change_help_send_action(_post_help)
 
         local_storage = interface.local_storage
         chain: GraiaMessageChain = await interface.lookup_param("message_chain", GraiaMessageChain, None)
-        result = self.alconna.analyse_message(chain)
         try:
-            result = self.alconna.analyse_message(chain)
+            result = self.analyser.analyse(chain)
         except ParamsUnmatched:
             traceback.print_exc()
             raise ExecutionStop
@@ -78,7 +115,7 @@ class AlconnaDispatcher(BaseDispatcher):
         if issubclass(interface.annotation, Arpamar):
             return arpamar
         if issubclass(interface.annotation, Alconna):
-            return self.alconna
+            return self.analyser.alconna
         if isinstance(interface.annotation, dict) and arpamar.options.get(interface.name):
             return arpamar.options[interface.name]
         if interface.name in arpamar.all_matched_args:
@@ -87,3 +124,4 @@ class AlconnaDispatcher(BaseDispatcher):
         if issubclass(interface.annotation, ArpamarProperty):
             return arpamar.get(interface.name)
         return Force()
+

--- a/src/graia/ariadne/message/parser/alconna.py
+++ b/src/graia/ariadne/message/parser/alconna.py
@@ -85,8 +85,8 @@ class AlconnaDispatcher(BaseDispatcher):
         if self.reply_help:
             app: Ariadne = get_running()
 
-            def _send_help_string(help_string: str):
-                app.loop.create_task(app.sendMessage(event.sender, GraiaMessageChain.create(help_string)))
+            async def _send_help_string(help_string: str):
+                await app.sendMessage(event.sender, GraiaMessageChain.create(help_string))
 
             change_help_send_action(_send_help_string)
         else:

--- a/src/graia/ariadne/message/parser/alconna.py
+++ b/src/graia/ariadne/message/parser/alconna.py
@@ -33,11 +33,19 @@ class AlconnaDispatcher(BaseDispatcher):
     Alconna的调度器形式
     """
 
-    def __init__(self, *, alconna: Alconna, reply_help: bool = False, block_catch: bool = True):
+    def __init__(self, *, alconna: Alconna, reply_help: bool = False, skip_for_unmatch: bool = True):
+        """
+        构造 Alconna调度器
+
+        Args:
+            alconna (Alconna): Alconna实例
+            reply_help (bool): 是否自助回复帮助信息给指令的发起者, 默认为 False
+            skip_for_unmatch (bool): 当指令匹配失败时是否跳过对应的事件监听器, 默认为 True
+        """
         super().__init__()
         self.alconna = alconna
         self.reply_help = reply_help
-        self.block_catch = block_catch
+        self.skip_for_unmatch = skip_for_unmatch
         if not reply_help:
             change_help_send_action(lambda x: x)
 
@@ -60,7 +68,7 @@ class AlconnaDispatcher(BaseDispatcher):
         except ParamsUnmatched:
             traceback.print_exc()
             raise ExecutionStop
-        if not result.matched and self.block_catch:
+        if not result.matched and self.skip_for_unmatch:
             raise ExecutionStop
         local_storage["arpamar"] = result
 


### PR DESCRIPTION
**更改说明**
加入一个kwonly的参数 skip_for_unmatch, 默认为True
该参数为True时, 若当前Alconna解析失败, 会抛出ExecutionStop

**向后兼容性**
当skip_for_unmatch为False时, 解析结果依然会被分配给事件监听器. 届时可能会出现一个命令发出导致多个事件监听器被调用
