### PR TITLE
:bulb: add `avatarId` to Group `getAvatar` method

### DIFF
--- a/src/graia/ariadne/model.py
+++ b/src/graia/ariadne/model.py
@@ -321,16 +321,18 @@ class Group(AriadneBaseModel):
 
         return await get_running().modifyGroupConfig(self, config)
 
-    async def getAvatar(self) -> bytes:
+    async def getAvatar(self, avatarId: int=1) -> bytes:
         """获取该群组的头像
-
+        Args:
+            avatarId: 群头像标号 (avatarId=1 为当前群头像 avatarId>1 为群封面)
+        
         Returns:
             bytes: 群头像的二进制内容.
         """
         from . import get_running
 
         return await (
-            await get_running().adapter.session.get(f"https://p.qlogo.cn/gh/{self.id}/{self.id}/")
+            await get_running().adapter.session.get(f"https://p.qlogo.cn/gh/{self.id}/{self.id}_{avatarId}/")
         ).content.read()
 
 

--- a/src/graia/ariadne/model.py
+++ b/src/graia/ariadne/model.py
@@ -321,11 +321,11 @@ class Group(AriadneBaseModel):
 
         return await get_running().modifyGroupConfig(self, config)
 
-    async def getAvatar(self, avatarId: int=1) -> bytes:
+    async def getAvatar(self, avatarId: int = 1) -> bytes:
         """获取该群组的头像
         Args:
             avatarId: 群头像标号 (avatarId=1 为当前群头像 avatarId>1 为群封面)
-        
+
         Returns:
             bytes: 群头像的二进制内容.
         """

--- a/src/graia/ariadne/model.py
+++ b/src/graia/ariadne/model.py
@@ -321,18 +321,19 @@ class Group(AriadneBaseModel):
 
         return await get_running().modifyGroupConfig(self, config)
 
-    async def getAvatar(self, avatarId: int = 1) -> bytes:
+    async def getAvatar(self, cover: Optional[int] = None) -> bytes:
         """获取该群组的头像
         Args:
-            avatarId: 群头像标号 (avatarId=1 为当前群头像 avatarId>1 为群封面)
+            cover (Optional[int]): 群封面标号 (若为 None 则获取该群头像, 否则获取该群封面)
 
         Returns:
             bytes: 群头像的二进制内容.
         """
         from . import get_running
 
+        cover = (cover or 0) + 1
         return await (
-            await get_running().adapter.session.get(f"https://p.qlogo.cn/gh/{self.id}/{self.id}_{avatarId}/")
+            await get_running().adapter.session.get(f"https://p.qlogo.cn/gh/{self.id}/{self.id}_{cover}/")
         ).content.read()
 
 


### PR DESCRIPTION
**更改说明**
为`Group`类的`getAvatar`添加群头像标号参数，以获取该群的其他封面

**向后兼容性**
无
