### PR TITLE
:art: Update typing.py

### DIFF
--- a/src/graia/ariadne/typing.py
+++ b/src/graia/ariadne/typing.py
@@ -120,10 +120,8 @@ def generic_issubclass(cls: type, par: Annotated[T, Union[type, Any, Tuple[type,
     if par is Any:
         return True
     try:
-        if isinstance(par, type):
+        if isinstance(par, (type, tuple)):
             return issubclass(cls, par)
-        if isinstance(par, tuple):
-            return any(issubclass(cls, p) for p in par)
         if typing.get_origin(par) is Union:
             return any(generic_issubclass(cls, p) for p in typing.get_args(par))
         if isinstance(par, TypeVar):
@@ -149,10 +147,8 @@ def generic_isinstance(obj: Any, par: Union[type, Any, Tuple[type, ...]]) -> boo
     if par is Any:
         return True
     try:
-        if isinstance(par, type):
+        if isinstance(par, (type, tuple)):
             return isinstance(obj, par)
-        if isinstance(par, tuple):
-            return any(isinstance(obj, p) for p in par)
         if typing.get_origin(par) is Union:
             return any(generic_isinstance(obj, p) for p in typing.get_args(par))
         if isinstance(par, TypeVar):


### PR DESCRIPTION
**更改说明**
合并了 `generic_issubclass` 和 `generic_isinstance` 中 par 为 `type` 和 `tuple` 的两个分支, 因为 Python3.8+ 均支持 `issubclass` 和 `isinstance` 的第二个参数为 "tuple of types".

**向后兼容性**
不会造成过去行为的改变.
