### PR TITLE
:bulb: support types.UnionType

### DIFF
--- a/src/graia/ariadne/typing.py
+++ b/src/graia/ariadne/typing.py
@@ -152,7 +152,7 @@ def generic_issubclass(cls: type, par: Union[type, Any, Tuple[type, ...]]) -> bo
             if par.__bound__:
                 return generic_issubclass(cls, par.__bound__)
         if isinstance(par, getattr(types, "UnionType", None)):
-            return isinstance(obj, par)
+            return isinstance(cls, par)
     return False
 
 

--- a/src/graia/ariadne/typing.py
+++ b/src/graia/ariadne/typing.py
@@ -4,6 +4,7 @@ import builtins
 import contextlib
 import enum
 import sys
+import types
 import typing
 from types import MethodType, TracebackType
 from typing import (
@@ -150,6 +151,8 @@ def generic_issubclass(cls: type, par: Union[type, Any, Tuple[type, ...]]) -> bo
                 return any(generic_issubclass(cls, p) for p in par.__constraints__)
             if par.__bound__:
                 return generic_issubclass(cls, par.__bound__)
+        if isinstance(par, getattr(types, "UnionType", None)):
+            return isinstance(obj, par)
     return False
 
 
@@ -175,6 +178,8 @@ def generic_isinstance(obj: Any, par: Union[type, Any, Tuple[type, ...]]) -> boo
                 return any(generic_isinstance(obj, p) for p in par.__constraints__)
             if par.__bound__:
                 return generic_isinstance(obj, par.__bound__)
+        if isinstance(par, getattr(types, "UnionType", None)):
+            return isinstance(obj, par)
     return False
 
 


### PR DESCRIPTION
**更改说明**
Support `Union` in form of `int | str` in Python3.10.

**向后兼容性**
不会造成过去行为的改变.
