### PR TITLE
:bug: HttpServerInfo misses verify_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 未发布的更新
 
+修复 `HttpServerInfo` 缺失 `verify_key` 导致 `TypeError` 问题.
+
 ## 0.7.18
 
 ### 修复

--- a/src/graia/ariadne/connection/_info.py
+++ b/src/graia/ariadne/connection/_info.py
@@ -31,6 +31,7 @@ class WebsocketServerInfo(NamedTuple):
 
 class HttpServerInfo(NamedTuple):
     account: int
+    verify_key: str
     path: str
     headers: Dict[str, str]
 


### PR DESCRIPTION
**更改说明**
修复 `HttpServerInfo` 缺失 `verify_key` 导致 `TypeError` 问题

**向后兼容性**
更改不会造成过去行为的改变.